### PR TITLE
job #35 - substitute ; for : in MGLS_LICENSE_FILE before running

### DIFF
--- a/bin/xtumlmc_build
+++ b/bin/xtumlmc_build
@@ -665,6 +665,7 @@ sub xtumlmc_gen_erate($)
   my $dos_or_unix = add_to_path( "$pt_home/$mc/bin" );
   my $gencmd = "gen_erate";
   my $rval = 0;
+  $ENV{'MGLS_LICENSE_FILE'} =~ s/:/;/g;
   if ( "win32" eq "$osplatform" ) {
     $rval = system( "$gencmd @param_list" );
   } else {


### PR DESCRIPTION
gen_erate.
