### PR TITLE
fixed a syntax error introduced by 210eea23

### DIFF
--- a/arc/q.class.pei.arc
+++ b/arc/q.class.pei.arc
@@ -124,7 +124,7 @@
   .//
   .// Generate the attribute value initializers.
   .//
-  .select any te_attr related by o_obj->TE_CLASS[R2019]-TE_ATTR[R2061] where ( selected.prevID == 0 )
+  .select any te_attr related by o_obj->TE_CLASS[R2019]->TE_ATTR[R2061] where ( selected.prevID == 0 )
   .if ( not_empty te_attr )
     .select one o_attr related by te_attr->O_ATTR[R2033]
     .while ( not_empty te_attr )


### PR DESCRIPTION
Hi!

While experimenting with my own little RSL parser based on [arlan.l](https://github.com/xtuml/bposs/blob/2c47abf74a3e6fadb174b08e57aa66a209400606/mc/mcmc/arlan/arlan.l) and [arlan.y](https://github.com/xtuml/bposs/blob/2c47abf74a3e6fadb174b08e57aa66a209400606/mc/mcmc/arlan/arlan.y), I encountered the following syntax error. 
I might have a few additional commits coming in, but they are not as strait forward as this one. Consequently,  I'll send them in using additional pull request(s).