### PR TITLE
8361 comments (follow up)

### DIFF
--- a/doc/notes/8361_comments/8361_comments_dnt.md
+++ b/doc/notes/8361_comments/8361_comments_dnt.md
@@ -95,13 +95,13 @@ cases
 5.2.1.1 Declaration and definition
 
 Some MASL elements have both a declaration and a definition. MASL objects and
-MASL types both have forward declarations. Activities (states, routines, and
-operations have declarations and definitions in separate files. xtUML has no
-notion of declaration and definition because it is not procedural as a textual
-language like MASL. Possible solutions to this problem are to multiplex the
-description field and tag two separate descriptions -- declaration and
-definition. Another solution is to combine the descriptions into one description
-stored in the corresponding model element.
+MASL types both have declarations before their definitions. Activities (states,
+routines, and operations have declarations and definitions in separate files.
+xtUML has no notion of declaration and definition because it is not procedural
+as a textual language like MASL. Possible solutions to this problem are to
+multiplex the description field and tag two separate descriptions -- declaration
+and definition. Another solution is to combine the descriptions into one
+description stored in the corresponding model element.
 
 5.2.1.2 Identifiers
 
@@ -121,8 +121,10 @@ to MASL descriptions.
 
 A solution to the declaration/definition problem would be to demultiplex the
 description fields (if using a tagged approach) and output multiple MASL
-descriptions. Alternatively, if the descriptions are consolidated into one
-field, the description could be output with the model element definition.
+descriptions. Alternatively, if the descriptions are consolidated (concatenated)
+into one field, the description could be output with the model element
+definition. A final solution could be to simply choose the description from the
+declaration, or from the definition.
 
 5.4 Model of MASL (`masl`)
 
@@ -138,6 +140,14 @@ to each object that can have a description.
 6. Design
 ---------
 
+6.0 iUML (like xtUML) is not procedural and has no notion of declaration and
+definition. Because of this, documentation comments from the iUML dumper will
+always be duplicated for declaration and definition. Because of this property,
+descriptions attached to declarations of model elements in MASL can safely be
+ignored. Since the declaration and definition of activities are in separate
+files, The documentation comments will be parsed and exported from the
+declaration in the `.mod` or `.prj` file.
+
 6.1 An element `description` is added to the serial MASL specification with the
 first argument being the text of the description and the second argument being
 the string tag. See [[2.1]](#2.1)
@@ -150,11 +160,17 @@ requirement 4.2.1 since the rule for regular comments is lines starting with
 `//`.
 
 6.2.2 A parse rule is added to read optional blocks of description comments and
-add AST nodes. This rule prepends the parse rule for each model element that
-can have a description.
+add AST nodes. A reference to this rule prepends the parse rule for each model
+element that can have a description. Both the declaration and definition rules
+will be prepended by the parse rule.
 
 6.2.3 A tree grammar (walker) rule is added to produce serial MASL from the
-parsed descriptions according to the serial MASL specification.
+parsed descriptions according to the serial MASL specification. A reference to
+this rule prepends the rule for each model element that can have a description.
+In the case of model elements with a declaration and a definition, this rule
+will only be added to the definition. In this way, it will be legal MASL to
+place a documentation comment before a declaration, however no serial MASL will
+be produced from it.
 
 6.3 The MASL to xtUML converter consolidates descriptions for object and type
 declarations and definitions and stores them in the `Descrip` fields of the

--- a/doc/notes/8361_comments/8361_comments_dnt.md
+++ b/doc/notes/8361_comments/8361_comments_dnt.md
@@ -15,7 +15,7 @@ of this flow.
 
 2. Document References
 ----------------------
-<a id="2.1"></a>2.1 [serial MASL specification](8073_masl_parser/8277_serial_masl_spec.md)  
+<a id="2.1"></a>2.1 [serial MASL specification](../8073_masl_parser/8277_serial_masl_spec.md)  
 <a id="2.2"></a>2.2 [#8361 Comment Support](https://support.onefact.net/issues/8361)  
 <a id="2.3"></a>2.3 [#8362 Map comments to model element descriptions (internal issue)](https://support.onefact.net/issues/8362)  
 

--- a/doc/notes/8361_comments/8361_comments_int.md
+++ b/doc/notes/8361_comments/8361_comments_int.md
@@ -1,0 +1,116 @@
+---
+
+This work is licensed under the Creative Commons CC0 License
+
+---
+
+# Model element descriptions in MASL convert/load and export
+### xtUML Project Implementation Note
+
+1. Abstract
+-----------
+See [[2.4]](#2.4) Section 1
+
+2. Document References
+----------------------
+<a id="2.1"></a>2.1 [serial MASL specification](../8073_masl_parser/8277_serial_masl_spec.md)  
+<a id="2.2"></a>2.2 [#8361 Comment Support](https://support.onefact.net/issues/8361)  
+<a id="2.3"></a>2.3 [#8362 Map comments to model element descriptions (internal issue)](https://support.onefact.net/issues/8362)  
+<a id="2.4"></a>2.4 [Design note](8361_comments_dnt.md)  
+
+3. Background
+-------------
+See [[2.4]](#2.4) Section 3
+
+4. Requirements
+---------------
+See [[2.4]](#2.4) Section 4
+
+5. Work Required
+----------------
+
+5.1. Update MASL parser grammars  
+5.1.1. Add lex rule for documentation comments  
+5.1.2. Add parser rule for blocks of documentation comments that make a
+description  
+5.1.3. Add a walker rule to produce serial MASL from the text of the
+descriptions  
+5.1.4. Add calls to the parser and walker rules within the appropriate rules
+throughout the grammars  
+5.2. Update `m2x` to handle the "description" serial MASL command and store the
+descriptions in xtUML `Descrip` fields  
+5.3. Update `x2m` to output serial MASL from the description fields of supported
+model elements  
+5.3.1. Make sure that other things that are stored in `Descrip` fields (pragmas
+and type definitions) are removed before the descriptions are rendered  
+5.4. Update the model of MASL to populate and render descriptions  
+5.4.1. Add `description` class and relate it to the `element` class  
+5.4.2. Add code to populate `description` on the "description" serial MASL
+command  
+5.4.3. Add code to render descriptions to the `render` operation of each
+supported model element  
+
+6. Implementation Comments
+--------------------------
+
+Some small tasks are also handled in this work due to convenience and/or
+dependence.
+
+6.1. Fixed bugs/updated behavior/propagated changes to the STRING bridge  
+6.2. Updated a file in the `gen/` folder to reflect the recent changes to add
+`Exception` to the meta-model  
+6.3. Changed the tag for type definitions from "definition:..." to XML style tags
+"<definition>...</definition>" to facilitate removing the definition from the
+`Descrip` field before rendering descriptions to serial MASL  
+6.4. Copied the specification of serial MASL into a markdown file alongside the
+MASL parser documentation
+6.4.1. Updated references to this documentation
+
+7. Unit Test
+------------
+See [[2.4]](#2.4) Section 8
+
+8. Code Changes
+---------------
+Branch name: 8361_comments
+
+<pre>
+
+doc/notes/8019_masl/8019_masl_dnt.md                                                |   2 +-
+doc/notes/8073_masl_parser/8073_masl_parser.dnt.md                                  |   2 +-
+doc/notes/8073_masl_parser/8277_serial_masl_spec.md                                 | 208 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+doc/notes/8211_masl_import/8211_masl_import_dnt.md                                  |   2 +-
+doc/review-minutes/8361_comments_dnt_rvm.md                                         |  31 +++++++++++
+masl/parser/src/MaslLexer.g                                                         |   1 +
+masl/parser/src/MaslParser.g                                                        |  69 +++++++++++++++++-------
+masl/parser/src/MaslWalker.g                                                        |  33 ++++++++++++
+model/masl/gen/STRING_bridge.c                                                      |  84 ++++++++++++++++++++++++-----
+model/masl/gen/masl_population_class.c                                              |  11 +++-
+model/masl/models/masl/masl/activity/activity.xtuml                                 |   6 ++-
+model/masl/models/masl/masl/attribute/attribute.xtuml                               |   6 ++-
+model/masl/models/masl/masl/domain/domain.xtuml                                     |  12 ++++-
+model/masl/models/masl/masl/event/event.xtuml                                       |   6 ++-
+model/masl/models/masl/masl/object/object.xtuml                                     |   7 ++-
+model/masl/models/masl/masl/project/project.xtuml                                   |   6 ++-
+model/masl/models/masl/masl/relationship/relationship.xtuml                         |   6 ++-
+model/masl/models/masl/masl/terminator/terminator.xtuml                             |   6 ++-
+model/masl/models/masl/maslpopulation/description/description.xtuml                 | 162 +++++++++++++++++++++++++++++++++++++++++++++++++++++++
+model/masl/models/masl/maslpopulation/maslpopulation.xtuml                          | 251 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++-
+model/masl/models/masl/maslpopulation/population/population.xtuml                   |   4 ++
+model/masl/models/masl/masltypes/type/type.xtuml                                    |   6 ++-
+model/maslin/gen/STRING_bridge.c                                                    |  10 +++-
+model/maslin/gen/masl2xtuml.c                                                       |   2 +
+model/maslin/gen/masl2xtuml_ooapopulation_class.c                                   | 222 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++------
+model/maslin/gen/masl2xtuml_ooapopulation_class.h                                   |   5 +-
+model/maslin/models/maslin/masl2xtuml/masl2xtuml.xtuml                              |  16 ++++--
+model/maslin/models/maslin/masl2xtuml/ooapopulation/ooapopulation.xtuml             | 163 +++++++++++++++++++++++++++++++++++++++++++++++++++-----
+model/maslout/gen/STRING_bridge.c                                                   |  70 +++++++++++++++++++-----
+model/maslout/models/maslout/lib/xtuml2masl/maslout_imported/maslout_imported.xtuml | 140 +++++++++++++++++++++++++++++++++++++++---------
+model/mcshared/models/mcshared/MC_EEs/MC_EEs.xtuml                                  |  27 ++++++++--
+31 files changed, 1449 insertions(+), 127 deletions(-)
+
+</pre>
+
+End
+---
+

--- a/masl/parser/src/MaslParser.g
+++ b/masl/parser/src/MaslParser.g
@@ -206,7 +206,6 @@ exceptionVisibility           : PRIVATE                                         
 typeForwardDeclaration        : description typeVisibility TYPE typeName SEMI pragmaList        ->^( TYPE_DECLARATION[$TYPE]
                                                                                                 typeName 
                                                                                                 typeVisibility 
-                                                                                                description
                                                                                                 pragmaList? )
                               ;
 
@@ -457,7 +456,6 @@ attributeName                 : identifier                                      
 
 objectDeclaration             : description OBJECT objectName SEMI pragmaList             -> ^( OBJECT_DECLARATION[$OBJECT] 
                                                                                                 objectName 
-                                                                                                description
                                                                                                 pragmaList?)
                               ;
 
@@ -803,7 +801,8 @@ description                   : Description*                                    
 
 
 
-domainServiceDefinition       : serviceVisibility serv=SERVICE 
+domainServiceDefinition       : description
+                                serviceVisibility serv=SERVICE 
                                 domainName SCOPE serviceName 
                                 parameterList IS 
                                 codeBlock 
@@ -816,7 +815,8 @@ domainServiceDefinition       : serviceVisibility serv=SERVICE
                                                                                                 pragmaList? )                               
                               ;
 
-domainFunctionDefinition      : serviceVisibility func=FUNCTION 
+domainFunctionDefinition      : description
+                                serviceVisibility func=FUNCTION 
                                   domainName SCOPE serviceName 
                                   parameterList 
                                   RETURN returnType IS codeBlock 
@@ -832,7 +832,8 @@ domainFunctionDefinition      : serviceVisibility func=FUNCTION
 
 
 
-objectServiceDefinition       : serviceVisibility INSTANCE? serv=SERVICE 
+objectServiceDefinition       : description
+                                serviceVisibility INSTANCE? serv=SERVICE 
                                   domainName SCOPE objectName DOT serviceName 
                                   parameterList IS codeBlock 
                                 SERVICE? SEMI pragmaList                                  -> ^( OBJECT_SERVICE_DEFINITION[$serv]
@@ -846,7 +847,8 @@ objectServiceDefinition       : serviceVisibility INSTANCE? serv=SERVICE
                                                                                                 pragmaList? )
                               ;
 
-terminatorServiceDefinition   : serviceVisibility serv=SERVICE 
+terminatorServiceDefinition   : description
+                                serviceVisibility serv=SERVICE 
                                 domainName SCOPE terminatorName TERMINATOR_SCOPE serviceName 
                                 parameterList IS 
                                 codeBlock 
@@ -860,7 +862,8 @@ terminatorServiceDefinition   : serviceVisibility serv=SERVICE
                                                                                                 pragmaList? )                               
                               ;
 
-terminatorFunctionDefinition  : serviceVisibility func=FUNCTION 
+terminatorFunctionDefinition  : description
+                                serviceVisibility func=FUNCTION 
                                 domainName SCOPE terminatorName TERMINATOR_SCOPE serviceName 
                                 parameterList RETURN returnType IS 
                                 codeBlock 
@@ -876,7 +879,8 @@ terminatorFunctionDefinition  : serviceVisibility func=FUNCTION
                               ;
 
 
-objectFunctionDefinition      : serviceVisibility serviceType func=FUNCTION 
+objectFunctionDefinition      : description
+                                serviceVisibility serviceType func=FUNCTION 
                                   domainName SCOPE objectName DOT serviceName 
                                   parameterList 
                                   RETURN returnType IS codeBlock 
@@ -893,7 +897,8 @@ objectFunctionDefinition      : serviceVisibility serviceType func=FUNCTION
                               ;
 
 
-stateDefinition               : stateType STATE 
+stateDefinition               : description
+                                stateType STATE 
                                 domainName SCOPE objectName DOT stateName 
                                 parameterList IS codeBlock 
                                 STATE? SEMI pragmaList                                    -> ^( STATE_DEFINITION 

--- a/masl/parser/src/MaslWalker.g
+++ b/masl/parser/src/MaslWalker.g
@@ -265,7 +265,6 @@ typeForwardDeclaration
                                                                   args[1] = $typeVisibility.visibility;
                                                                   populate( "type", args );
                                                               }
-                                   description
                                    pragmaList[""]				
                                  )                          
                                                               {
@@ -699,7 +698,6 @@ objectDeclaration
                                                                 args[0] = $objectName.name;
                                                                 populate( "object", args );
                                                             }
-                                   description
                                    pragmaList["declaration"]
                                  )                          
                                                             {


### PR DESCRIPTION
This PR addresses comments from the user.

We can be sure that there will never be two unique comments on a model element declaration and definition. Consequently, we can safely choose just one of the comments (definition for objects and types, declaration for activities) to populate the Descrip fields.

There was also a bug that there was no parse rule prepending activity definitions for documentation comments. We know that the iUML dumper will give us documentation comments in activity files, so even though we will throw them away, we have to parse them.