### PR TITLE
job:  #9165  This commit makes sure we do not lose comments on refere…

### DIFF
--- a/model/maslin/models/maslin/m2x/ooapopulation/ooapopulation.xtuml
+++ b/model/maslin/models/maslin/m2x/ooapopulation/ooapopulation.xtuml
@@ -3368,10 +3368,12 @@ select many battrs related by o_obj->O_ATTR[R102]->O_BATTR[R106]->O_ATTR[R106];
 select many rattrs related by o_obj->O_ATTR[R102]->O_RATTR[R106]->O_ATTR[R106];
 for each battr in battrs
   for each rattr in rattrs
-	if ( rattr.Root_Nam == battr.Root_Nam )
-	  self.Attribute_dispose( o_attr:battr ); // delete any base attribute that has the same name as a referential attribute
+    if ( rattr.Root_Nam == battr.Root_Nam )
+      // Copy over the description field from the attribute being combined.
+      rattr.Descrip = rattr.Descrip + battr.Descrip;
+      self.Attribute_dispose( o_attr:battr ); // delete any base attribute that has the same name as a referential attribute
       break;
-	end if;
+    end if;
   end for;
 end for;',
 	1,

--- a/model/maslin/models/maslin/m2x/referentialAttribute/referentialAttribute.xtuml
+++ b/model/maslin/models/maslin/m2x/referentialAttribute/referentialAttribute.xtuml
@@ -42,6 +42,8 @@ if ( not_empty o_attr )
   select many o_attrs related by o_attr->O_OBJ[R102]->O_ATTR[R102]->O_RATTR[R106]->O_ATTR[R106];
   for each dup_o_attr in o_attrs
 	if ( dup_o_attr != o_attr and dup_o_attr.Root_Nam == o_attr.Root_Nam )
+	  // Copy over the description field from the attribute being combined.
+	  o_attr.Descrip = o_attr.Descrip + dup_o_attr.Descrip;
 	  ooapopulation.ReferentialAttribute_combine_refs( o_attr:o_attr, other_attr:dup_o_attr );
 	end if;
   end for;


### PR DESCRIPTION
…ntial attributes during Import (m2x).  This works by copying over the Descrip field from a base attribute being replaced by a referential.  It also makes sure we preserve the Descrip in the case of combining referentials.