### PR TITLE
cli: ensure that ply, pyxtuml and pyrsl from gen_erate.pyz is used

### DIFF
--- a/bin/mc3020.py
+++ b/bin/mc3020.py
@@ -11,8 +11,8 @@ import logging
 import sys
 import os
 
-# use pyxtuml and pyrsl bundled in gen_erate.pyz
-sys.path.append(os.path.dirname(__file__) + '/gen_erate.pyz') 
+# use ply, pyxtuml and pyrsl bundled in gen_erate.pyz
+sys.path.insert(0, os.path.dirname(__file__) + '/gen_erate.pyz') 
 
 import xtuml
 import rsl


### PR DESCRIPTION
If a different version of ply is installed in the python site-packages,
the rsl parser tries to recreate parse tables on every parsed archetype
file. This patch gives ply bundled in gen_erate.pyz precedence.