### PR TITLE
use 128bit integer to represent unique_id on supported platforms

### DIFF
--- a/arc/c/t.sys_sets.h
+++ b/arc/c/t.sys_sets.h
@@ -59,6 +59,7 @@ typedef struct {
 .end if
 } ${te_extent.type};
 
+#define $u{te_prefix.type}GET_BITS(v,b,m) (b < sizeof(v)*8 ? (m & (v >> b)) : 0)
 ${te_prefix.type}UniqueID_t ${te_prefix.type}ID_factory( void );
 ${te_prefix.type}UniqueID_t ${te_prefix.type}ID_deserialize( const c_t * );
 void ${te_set.factory}( const i_t );

--- a/arc/c/t.sys_sets.h
+++ b/arc/c/t.sys_sets.h
@@ -60,6 +60,7 @@ typedef struct {
 } ${te_extent.type};
 
 ${te_prefix.type}UniqueID_t ${te_prefix.type}ID_factory( void );
+${te_prefix.type}UniqueID_t ${te_prefix.type}ID_deserialize( const c_t * );
 void ${te_set.factory}( const i_t );
 void ${te_set.copy}( ${te_set.base_class} *,
                 ${te_set.base_class} * const );

--- a/arc/c/t.sys_types.h
+++ b/arc/c/t.sys_types.h
@@ -123,7 +123,11 @@ typedef struct {
 ${inst_id_in_handle}\
 } ${te_instance.base};
 typedef ${te_instance.base} * ${te_instance.handle};
+#ifdef __SIZEOF_INT128__
+typedef __int128 ${te_prefix.type}UniqueID_t;
+#else
 typedef i_t ${te_prefix.type}UniqueID_t;
+#endif
 typedef void (*Escher_idf)( Escher_iHandle_t ); 
 
 /* Return code type for dispatch of a polymorphic event (see ${te_file.events}.${te_file.hdr_file_ext}).  */

--- a/arc/q.class.factory.arc
+++ b/arc/q.class.factory.arc
@@ -128,7 +128,7 @@ ${te_class.GeneratedName}_instanceloader( ${te_instance.handle} instance, const 
           .assign attribute_number = attribute_number + 1
         .elif ( 5 == te_dt.Core_Typ )
           .// unique_id
-  ${te_instance.self}->${te_attr.GeneratedName} = ${te_instance.module}${te_string.atoi}( avlstring[ ${attribute_number} ] );
+  ${te_instance.self}->${te_attr.GeneratedName} = ${te_prefix.type}ID_deserialize( avlstring[ ${attribute_number} ] );
           .select any o_oida related by o_attr->O_OIDA[R105] where ( selected.Oid_ID == 0 )
           .select one o_rattr related by o_attr->O_RATTR[R106]
           .if ( ( not_empty o_oida ) and ( empty o_rattr ) )

--- a/arc/q.sys.populate.arc
+++ b/arc/q.sys.populate.arc
@@ -490,7 +490,7 @@
       .// unique_id
       .assign te_dt.ExtName = te_prefix.type + "UniqueID_t"
       .assign te_dt.Initial_Value = "0"
-      .assign te_dt.string_format = "%d"
+      .assign te_dt.string_format = "\""%08lx-%04x-%04x-%04x-%04x%08lx\"""
       .//
     .elif ( 6 == te_dt.Core_Typ )
       .// current_state
@@ -1503,6 +1503,14 @@
           .if ( "%p" == te_dt.string_format )
             .assign te_class.attribute_format = ( te_class.attribute_format + delimiter ) + "%ld"
             .assign te_class.attribute_dump = ( te_class.attribute_dump + ",\n    ((long)self->" ) + ( te_attr.GeneratedName + " & ESCHER_IDDUMP_MASK)" )
+          .elif ( 5 == te_dt.Core_Typ ) .// unique_id
+            .assign te_class.attribute_format = ( te_class.attribute_format + delimiter ) + te_dt.string_format
+            .assign te_class.attribute_dump = ( te_class.attribute_dump + ",\n    (u4_t)$u{te_prefix.type}GET_BITS(self->${te_attr.GeneratedName}, 96, 0xffffffff)" )
+            .assign te_class.attribute_dump = ( te_class.attribute_dump + ",\n    (u2_t)$u{te_prefix.type}GET_BITS(self->${te_attr.GeneratedName}, 80, 0xffff)" )
+            .assign te_class.attribute_dump = ( te_class.attribute_dump + ",\n    (u2_t)$u{te_prefix.type}GET_BITS(self->${te_attr.GeneratedName}, 64, 0xffff)" )
+            .assign te_class.attribute_dump = ( te_class.attribute_dump + ",\n    (u2_t)$u{te_prefix.type}GET_BITS(self->${te_attr.GeneratedName}, 48, 0xffff)" )
+            .assign te_class.attribute_dump = ( te_class.attribute_dump + ",\n    (u2_t)$u{te_prefix.type}GET_BITS(self->${te_attr.GeneratedName}, 32, 0xffff)" )
+            .assign te_class.attribute_dump = ( te_class.attribute_dump + ",\n    (u4_t)$u{te_prefix.type}GET_BITS(self->${te_attr.GeneratedName}, 0 , 0xffffffff)" )
           .elif ( "%s" == te_dt.string_format )
             .// Place an escaped tick mark around the %s in the attribute format string.
             .assign te_class.attribute_format = ( ( te_class.attribute_format + delimiter ) + ( "'" + te_dt.string_format ) ) + "'"

--- a/arc/t.sys_sets.c
+++ b/arc/t.sys_sets.c
@@ -25,6 +25,43 @@ ${te_prefix.type}ID_factory( void )
 }
 
 /*
+ * Deserialize a GUID into a unique integer ID.
+ */
+${te_prefix.type}UniqueID_t
+${te_prefix.type}ID_deserialize( const c_t * s )
+{
+  u1_t b;
+  ${te_prefix.type}UniqueID_t v = 0;
+
+  while(*s) {
+    b = *s++;
+
+    switch(b) {
+    case '0'...'9':
+      b -= '0';
+      break;
+
+    case 'a'...'f':
+      b -= 'a';
+      b += 10;
+      break;
+
+    case 'A'...'F':
+      b -= 'A';
+      b += 10;
+    break;
+
+    default:
+      continue;
+    }
+    v = (v << 4) | (b & 0xF);
+  }
+
+  return v;
+}
+
+
+/*
  * Detect empty handles in expressions.
  */
 void * xtUML_detect_empty_handle( void * h, const char * s1, const char * s2 )


### PR DESCRIPTION
Hi!

This seems to work for me. Note that there is no format string for printf for these types.
I have **not** tested this with load/persist in mc3020, I have never use that feature so not sure where to look. However, I have used it from a model that invokes a bridges to convert to/from string. Below is the hand-written mc3020 c code for these bridges.

```c
/*
 * Bridge:  To_Unique_Id
 */
Escher_UniqueID_t
STR_To_Unique_Id( c_t p_value[ESCHER_SYS_MAX_STRING_LEN] )
{
  unsigned char uuid[16];
  Escher_UniqueID_t value;
  
  sscanf(p_value,
	 "%02hhx%02hhx%02hhx%02hhx-"
	 "%02hhx%02hhx-"
	 "%02hhx%02hhx-"
	 "%02hhx%02hhx-"
	 "%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx",
	 &uuid[15], &uuid[14], &uuid[13], &uuid[12],
	 &uuid[11], &uuid[10],
	 &uuid[9], &uuid[8],
	 &uuid[7], &uuid[6],
	 &uuid[5], &uuid[4], &uuid[3], &uuid[2], &uuid[1], &uuid[0]);

  memcpy(&value, uuid, sizeof(Escher_UniqueID_t));
    
  return value;
}

/*
 * Bridge:  From_Unique_Id
 */
c_t *
STR_From_Unique_Id( c_t A0xtumlsret[ESCHER_SYS_MAX_STRING_LEN], Escher_UniqueID_t p_value )
{
  unsigned char uuid[16];
 
  memset(uuid, 0, sizeof(uuid));
  memcpy(uuid, &p_value, sizeof(Escher_UniqueID_t));

  snprintf(A0xtumlsret,
	   ESCHER_SYS_MAX_STRING_LEN,
	   "%02hhx%02hhx%02hhx%02hhx-"
	   "%02hhx%02hhx-"
	   "%02hhx%02hhx-"
	   "%02hhx%02hhx-"
	   "%02hhx%02hhx%02hhx%02hhx%02hhx%02hhx",
	   uuid[15], uuid[14], uuid[13], uuid[12],
	   uuid[11], uuid[10],
	   uuid[9], uuid[8],
	   uuid[7], uuid[6],
	   uuid[5], uuid[4], uuid[3], uuid[2], uuid[1], uuid[0]);

  return A0xtumlsret;
}

```
The bridges themselves also works with 32bit representations, but will truncate the upper 96bits. Perhaps a better solution for such platforms is to hash the string and hope that no collisions occur. This ought to work for 64 bits since collisions are very rare, at least if you use the same hashing algorithm as python use.
