### PR TITLE
10374 close state file

### DIFF
--- a/arc/t.ee.ss.c
+++ b/arc/t.ee.ss.c
@@ -155,6 +155,8 @@ sstrigger()
   metadata.ievents = ievent_count;
   fwrite( &metadata, sizeof( ssmeta_t ), 1, ssfile );
   fwrite( ssbuf, sizeof( ssdata_t ), instance_count + sevent_count + ievent_count, ssfile );
+  if ( ssfile != stdout )
+    fclose( ssfile );
 }
 #else
 .include "${te_file.arc_path}/t.ee.ss.main.c"

--- a/arc/t.sys_ilb.c
+++ b/arc/t.sys_ilb.c
@@ -5,7 +5,7 @@
 
 typedef void ( * interleaved_bridge_t )( void );
 static interleaved_bridge_t interleaved_bridges[ ${te_ilb.define_name} ];
-typedef struct { u4_t space[ ${te_ilb.data_define_name} / sizeof(u4_t) ]; } ilb_data_t;
+typedef struct { u4_t space[ (${te_ilb.data_define_name} + sizeof(u4_t) - 1) / sizeof(u4_t) ]; } ilb_data_t;
 static ilb_data_t ilb_data[ ${te_ilb.define_name} ];
 static u1_t ilb_head = 0;
 static u1_t ilb_tail = 0;

--- a/arc/t.sys_ilb.c
+++ b/arc/t.sys_ilb.c
@@ -5,7 +5,7 @@
 
 typedef void ( * interleaved_bridge_t )( void );
 static interleaved_bridge_t interleaved_bridges[ ${te_ilb.define_name} ];
-typedef struct { u1_t space[ ${te_ilb.data_define_name} ]; } ilb_data_t;
+typedef struct { u4_t space[ ${te_ilb.data_define_name} / sizeof(u4_t) ]; } ilb_data_t;
 static ilb_data_t ilb_data[ ${te_ilb.define_name} ];
 static u1_t ilb_head = 0;
 static u1_t ilb_tail = 0;


### PR DESCRIPTION
Closes the state data file, which appears to have been a mere oversight in the original code.

Without this change, you might be left with an empty state data file if you abort the program shortly after triggering. Tested on Linux.

tested-by: Bll Gatliff <bgat@billgatliff.com>
