### PR TITLE
12562 wasl sensitive

### DIFF
--- a/arc/t.sys_maslload.c
+++ b/arc/t.sys_maslload.c
@@ -149,17 +149,18 @@ static int ${te_prefix.result}MASL_load_file( const char * filepath, const struc
    * Open the named file for reading.
    */
   ${te_prefix.type}size_t len = ${te_prefix.result}strlen(filepath);
-  if ( !( '.' == filepath[len-5] &&
-          'm' == filepath[len-4] &&
-          'a' == filepath[len-3] &&
-          's' == filepath[len-2] &&
-          'l' == filepath[len-1] ) ) {
-    return 0; // not a masl source file
-  } else {
+  if ( ( len > 5 ) &&
+       ( '.' == filepath[len-5] &&
+         'm' == filepath[len-4] &&
+         'a' == filepath[len-3] &&
+         's' == filepath[len-2] &&
+         'l' == filepath[len-1] ) ) {
     if ( (xtumlfile = fopen( filepath, "r" )) == 0 ) {
       fprintf( stderr, "Could not open file:  %s\n", filepath );
       return 1;
     }
+  } else {
+    return 0; // not a masl source file
   }
   init();               /* Initialize the parser storage area.  */
   /*

--- a/arc/t.sys_maslload.c
+++ b/arc/t.sys_maslload.c
@@ -148,7 +148,12 @@ static int ${te_prefix.result}MASL_load_file( const char * filepath, const struc
   /*
    * Open the named file for reading.
    */
-  if ( !strstr( filepath, ".masl" ) ) {
+  ${te_prefix.type}size_t len = ${te_prefix.result}strlen(filepath);
+  if ( !( '.' == filepath[len-5] &&
+          'm' == filepath[len-4] &&
+          'a' == filepath[len-3] &&
+          's' == filepath[len-2] &&
+          'l' == filepath[len-1] ) ) {
     return 0; // not a masl source file
   } else {
     if ( (xtumlfile = fopen( filepath, "r" )) == 0 ) {

--- a/arc/t.sys_xtumlload.c
+++ b/arc/t.sys_xtumlload.c
@@ -127,18 +127,19 @@ static int ${te_prefix.result}xtUML_load_file( const char * filepath, const stru
     /*
      * Only process files with names ending in .xtuml.
      */
-    if ( !( '.' == filepath[len-6] &&
-            'x' == filepath[len-5] &&
-            't' == filepath[len-4] &&
-            'u' == filepath[len-3] &&
-            'm' == filepath[len-2] &&
-            'l' == filepath[len-1] ) ) {
-      return 0; // not a model source file
-    } else {
+    if ( ( len > 6 ) &&
+         ( '.' == filepath[len-6] &&
+           'x' == filepath[len-5] &&
+           't' == filepath[len-4] &&
+           'u' == filepath[len-3] &&
+           'm' == filepath[len-2] &&
+           'l' == filepath[len-1] ) ) {
       if ( (xtumlfile = fopen( filepath, "r" )) == 0 ) {
         fprintf( stderr, "Could not open file:  %s\n", filepath );
         return 1;
       }
+    } else {
+      return 0; // not a model source file
     }
   }
   init();               /* Initialize the parser storage area.  */

--- a/arc/t.sys_xtumlload.c
+++ b/arc/t.sys_xtumlload.c
@@ -123,7 +123,16 @@ static int ${te_prefix.result}xtUML_load_file( const char * filepath, const stru
   if ( 0 == filepath ) {
     xtumlfile = stdin;
   } else {
-    if ( !strstr( filepath, ".xtuml" ) ) {
+    ${te_prefix.type}size_t len = ${te_prefix.result}strlen(filepath);
+    /*
+     * Only process files with names ending in .xtuml.
+     */
+    if ( !( '.' == filepath[len-6] &&
+            'x' == filepath[len-5] &&
+            't' == filepath[len-4] &&
+            'u' == filepath[len-3] &&
+            'm' == filepath[len-2] &&
+            'l' == filepath[len-1] ) ) {
       return 0; // not a model source file
     } else {
       if ( (xtumlfile = fopen( filepath, "r" )) == 0 ) {

--- a/doc/notes/12562_wasl_sensitive_int.adoc
+++ b/doc/notes/12562_wasl_sensitive_int.adoc
@@ -1,0 +1,85 @@
+= WASL Exporter File Sensitivity
+
+xtUML Project Implementation Note
+
+== 1 Abstract
+
+This note documents a small change to enhance the file system traversal
+in `x2m` to be more selective, avoiding files placed in the `/models`
+folder by other processes, such as configuration management (ClearCase).
+
+== 2 Introduction and Background
+
+It was reported that the WASL Exporter emitted erroneous data when
+non-BridgePoint files had been added to the project in the `/models`
+folder.  Upon closer investigation, it was isolated to a mechanism
+in ClearCase which copies user files and appends a special extension
+(`.contrib` or something like that) to the file.  For example, if
+`DomainA.xtuml` had been modified, ClearCase may keep a copy of that file
+named `DomainA.xtuml.contrib`.
+
+Additional investigation found that the `x2m` process recursively
+navigates the models folder matching files with '.xtuml' in the name.
+Both files above match this criteria.
+
+It is clear that this file matching must be made to match '.xtuml' only at
+the _end_ of the file name.
+
+== 3 Requirements
+
+=== 3.1 File Matching in `x2m`
+
+Match files with '.xtuml' in the name and only at the end of the name.
+
+== 4 Work Required
+
+The change is in the MC-3020 model compiler.  The file loader template
+shall be udpated to be more selective.
+
+== 5 Implementation Comments
+
+=== 5.1 MASL File Loader
+
+The exact same pattern occurs in the MASL file loader.  MASL files are
+matched with '.masl' in the name (not necessarily at the end), in the same
+way that '.xtuml' files are matched.  This work shall fix the weakness in
+this spot, too.
+
+== 6 Unit Test
+
+=== 6.1 MASL Round Trip
+
+Get clean results on MASL Round Trip.
+
+=== 6.2 Inject Erroneous Files
+
+. Run the WASL Exporter on a model.
+. See good results.
+. Copy `DomainA.xtuml` to DomainA.xtuml.contrib` with junk in the file.
+. See the same good results.
+
+== 7 User Documentation
+
+No documentation changes are necessary.
+
+== 8 Code Changes
+
+- fork/repository:  cortlandstarrett/mc
+- branch:  12562_wasl_sensitive
+
+----
+ arc/t.sys_maslload.c                    |  7 ++++++-
+ arc/t.sys_xtumlload.c                   | 11 +++++++++-
+ doc/notes/12562_wasl_sensitive_int.adoc | 87 ++++++++++++++++++++++++++++
+ 3 files changed, 103 insertions(+), 2 deletions(-)
+----
+
+== 9 Document References
+
+. [[dr-1]] https://support.onefact.net/issues/12562[12562 - WASL Exporter sensitive to additional files in the xtUML model]
+
+---
+
+This work is licensed under the Creative Commons CC0 License
+
+---


### PR DESCRIPTION
Here is a link to a branch build with MASL round trip behaving the same as master.
It is actually tricky to reproduce the problem, because the xtuml loader is kinda picky and excludes junk.  So, it takes .xtuml files with stuff that is "wrong but close" to cause a problem.

https://s3.amazonaws.com/xtuml-releases/cort-build/buildfiles.html
