### PR TITLE
job #12728: update WASL output for collection types

### DIFF
--- a/model/masl/models/masl/masltypes/typeref/typeref.xtuml
+++ b/model/masl/models/masl/masltypes/typeref/typeref.xtuml
@@ -22,6 +22,12 @@ elif ( "WASL" == genfile::architecture() )
     // WASL uses classname_IH for instance handles.
     mybody = STRING::substr( s:mybody, begin:12, end:STRING::strlen( s:mybody ) );
     mybody = mybody + "_IH";
+  elif ( STRING::indexof( haystack:mybody, needle:"sequence of " ) > -1 )
+  	// WASL does not have sequence and set types directly. Collections are implied by the use of a structure
+    mybody = STRING::substr( s:mybody, begin: STRING::strlen( s:"sequence of " ), end:STRING::strlen( s:mybody ) );
+  elif ( STRING::indexof( haystack:mybody, needle:"set of " ) > -1 )
+  	// WASL does not have sequence and set types directly. Collections are implied by the use of a structure
+    mybody = STRING::substr( s:mybody, begin: STRING::strlen( s:"set of " ), end:STRING::strlen( s:mybody ) );
   else
     doublecolon = STRING::indexof( haystack:mybody, needle:"::" );
     if ( doublecolon > -1 )


### PR DESCRIPTION
ASL implicitly considers all structure typed parameters to be sets. ASL does not support collection types other than with structures. In order for MASL conversion to work, the parameter needs to be typed as a collection. To support this, simply remove the 'sequence of' or 'set of' from the front of a collection type on WASL output.